### PR TITLE
Feature#00005 : [Phase 1] Implement Browser Local Storage Option

### DIFF
--- a/client/src/lib/browser-storage.ts
+++ b/client/src/lib/browser-storage.ts
@@ -1,0 +1,113 @@
+import type { RouteHistory, InsertRouteHistory } from '@/../../shared/schema';
+
+const ROUTE_HISTORY_KEY = 'route_monitoring_history';
+const STORAGE_VERSION = '1.0';
+
+interface StoredHistoryData {
+  version: string;
+  histories: Record<number, RouteHistory[]>; // routeId -> RouteHistory[]
+}
+
+class BrowserHistoryStorage {
+  private getStorageData(): StoredHistoryData {
+    try {
+      const data = localStorage.getItem(ROUTE_HISTORY_KEY);
+      if (!data) {
+        return { version: STORAGE_VERSION, histories: {} };
+      }
+      
+      const parsed = JSON.parse(data) as StoredHistoryData;
+      
+      // Handle version migrations if needed
+      if (parsed.version !== STORAGE_VERSION) {
+        return { version: STORAGE_VERSION, histories: {} };
+      }
+      
+      return parsed;
+    } catch (error) {
+      console.error('Error reading browser storage:', error);
+      return { version: STORAGE_VERSION, histories: {} };
+    }
+  }
+
+  private setStorageData(data: StoredHistoryData): void {
+    try {
+      localStorage.setItem(ROUTE_HISTORY_KEY, JSON.stringify(data));
+    } catch (error) {
+      console.error('Error writing to browser storage:', error);
+    }
+  }
+
+  getRouteHistories(routeId: number): RouteHistory[] {
+    const data = this.getStorageData();
+    return data.histories[routeId] || [];
+  }
+
+  addRouteHistory(routeId: number, history: InsertRouteHistory): RouteHistory {
+    const data = this.getStorageData();
+    
+    if (!data.histories[routeId]) {
+      data.histories[routeId] = [];
+    }
+
+    // Generate a unique ID based on timestamp and random
+    const id = Date.now() + Math.floor(Math.random() * 1000);
+    const newHistory: RouteHistory = {
+      id,
+      routeId,
+      timestamp: new Date(),
+      travelTime: history.travelTime,
+      change: history.change ?? null,
+    };
+
+    data.histories[routeId].unshift(newHistory);
+    
+    // Limit history to prevent storage bloat (keep last 1000 entries per route)
+    if (data.histories[routeId].length > 1000) {
+      data.histories[routeId] = data.histories[routeId].slice(0, 1000);
+    }
+
+    this.setStorageData(data);
+    return newHistory;
+  }
+
+  deleteRouteHistories(routeId: number): void {
+    const data = this.getStorageData();
+    delete data.histories[routeId];
+    this.setStorageData(data);
+  }
+
+  clearAllHistories(): void {
+    const data: StoredHistoryData = { version: STORAGE_VERSION, histories: {} };
+    this.setStorageData(data);
+  }
+
+  getStorageSize(): number {
+    try {
+      const data = localStorage.getItem(ROUTE_HISTORY_KEY);
+      return data ? new Blob([data]).size : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  exportHistories(): string {
+    const data = this.getStorageData();
+    return JSON.stringify(data, null, 2);
+  }
+
+  importHistories(jsonData: string): boolean {
+    try {
+      const parsed = JSON.parse(jsonData) as StoredHistoryData;
+      if (parsed.version && parsed.histories) {
+        this.setStorageData(parsed);
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export const browserHistoryStorage = new BrowserHistoryStorage();

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -7,7 +7,7 @@ import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { Setting } from "@shared/schema";
 import { Card, CardContent } from "@/components/ui/card";
-import { Form, FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormDescription } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -23,6 +23,7 @@ const settingsFormSchema = z.object({
   enableNotifications: z.boolean().default(true),
   notificationType: z.enum(["all", "significant", "increase"]),
   historyRetention: z.string(),
+  storageLocation: z.enum(["server", "browser"]).default("server"),
 });
 
 type SettingsFormValues = z.infer<typeof settingsFormSchema>;
@@ -46,12 +47,14 @@ export default function Settings() {
       enableNotifications: settings?.enableNotifications ?? true,
       notificationType: settings?.notificationType as "all" | "significant" | "increase" || "all",
       historyRetention: settings?.historyRetention?.toString() || "30",
+      storageLocation: settings?.storageLocation as "server" | "browser" || "server",
     },
     values: settings ? {
       apiKey: settings.apiKey || "",
       enableNotifications: settings.enableNotifications,
       notificationType: settings.notificationType as "all" | "significant" | "increase",
       historyRetention: settings.historyRetention?.toString() || "30",
+      storageLocation: settings.storageLocation as "server" | "browser" || "server",
     } : undefined,
   });
 
@@ -128,6 +131,7 @@ export default function Settings() {
   const onSubmitDataSettings = (values: Partial<SettingsFormValues>) => {
     updateSettingsMutation.mutate({
       historyRetention: values.historyRetention,
+      storageLocation: values.storageLocation,
     });
   };
 
@@ -335,6 +339,34 @@ export default function Settings() {
           <div className="bg-neutral-100 rounded-lg p-4">
             <Form {...form}>
               <form onSubmit={form.handleSubmit(onSubmitDataSettings)} className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="storageLocation"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Storage Location</FormLabel>
+                      <Select 
+                        value={field.value} 
+                        onValueChange={field.onChange}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select storage location" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="server">Server Storage</SelectItem>
+                          <SelectItem value="browser">Browser Storage (Private)</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Browser storage keeps your route history private and local to your device, 
+                        while server storage allows access from any device but uses server resources.
+                      </FormDescription>
+                    </FormItem>
+                  )}
+                />
+                
                 <FormField
                   control={form.control}
                   name="historyRetention"

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -64,10 +64,11 @@ export class MemStorage implements IStorage {
     // Create default settings
     this.settings = {
       id: 1,
-      apiKey: process.env.GOOGLE_MAPS_API_KEY,
+      apiKey: process.env.GOOGLE_MAPS_API_KEY || null,
       enableNotifications: true,
       notificationType: "all",
       historyRetention: 30,
+      storageLocation: "server",
     };
   }
 
@@ -110,10 +111,21 @@ export class MemStorage implements IStorage {
     const id = this.routeId++;
     const now = new Date();
     const route: Route = { 
-      ...insertRoute, 
-      id, 
+      id,
+      name: insertRoute.name,
+      source: insertRoute.source,
+      destination: insertRoute.destination,
+      interval: insertRoute.interval ?? 15,
+      isActive: insertRoute.isActive ?? false,
+      isSaved: insertRoute.isSaved ?? false,
       lastChecked: now,
-      change: null, // Initialize change as null
+      currentTime: null,
+      minTime: null,
+      maxTime: null,
+      avgTime: null,
+      change: null,
+      sourceDetails: insertRoute.sourceDetails ?? null,
+      destinationDetails: insertRoute.destinationDetails ?? null,
     };
     this.routes.set(id, route);
     return route;
@@ -145,9 +157,11 @@ export class MemStorage implements IStorage {
   async createRouteHistory(insertHistory: InsertRouteHistory): Promise<RouteHistory> {
     const id = this.routeHistoryId++;
     const history: RouteHistory = { 
-      ...insertHistory, 
       id,
-      timestamp: insertHistory.timestamp || new Date()
+      routeId: insertHistory.routeId,
+      timestamp: insertHistory.timestamp || new Date(),
+      travelTime: insertHistory.travelTime,
+      change: insertHistory.change ?? null,
     };
     this.routeHistories.set(id, history);
     return history;
@@ -155,7 +169,7 @@ export class MemStorage implements IStorage {
 
   async deleteRouteHistories(routeId: number): Promise<boolean> {
     let success = true;
-    for (const [id, history] of this.routeHistories.entries()) {
+    for (const [id, history] of Array.from(this.routeHistories.entries())) {
       if (history.routeId === routeId) {
         success = this.routeHistories.delete(id) && success;
       }
@@ -172,9 +186,12 @@ export class MemStorage implements IStorage {
   async createNotification(insertNotification: InsertNotification): Promise<Notification> {
     const id = this.notificationId++;
     const notification: Notification = { 
-      ...insertNotification, 
       id,
-      timestamp: insertNotification.timestamp || new Date()
+      routeId: insertNotification.routeId,
+      timestamp: insertNotification.timestamp || new Date(),
+      type: insertNotification.type,
+      message: insertNotification.message,
+      isRead: insertNotification.isRead ?? false,
     };
     this.notifications.set(id, notification);
     return notification;
@@ -203,15 +220,16 @@ export class MemStorage implements IStorage {
     if (!this.settings) {
       this.settings = {
         id: 1,
-        ...updates,
+        apiKey: updates.apiKey ?? null,
         enableNotifications: updates.enableNotifications ?? true,
         notificationType: updates.notificationType ?? "all",
         historyRetention: updates.historyRetention ?? 30,
+        storageLocation: updates.storageLocation ?? "server",
       };
     } else {
       this.settings = { ...this.settings, ...updates };
     }
-    return this.settings;
+    return this.settings!;
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -72,6 +72,7 @@ export const settings = pgTable("settings", {
   enableNotifications: boolean("enable_notifications").notNull().default(true),
   notificationType: text("notification_type").notNull().default("all"), // 'all', 'significant', 'increase'
   historyRetention: integer("history_retention").notNull().default(30), // in days
+  storageLocation: text("storage_location").notNull().default("server"), // 'server', 'browser'
 });
 
 export const insertSettingsSchema = createInsertSchema(settings).omit({
@@ -104,4 +105,5 @@ export const routeFormSchema = insertRouteSchema.extend({
 
 export const settingsFormSchema = insertSettingsSchema.extend({
   apiKey: z.string().min(1, "API key is required"),
+  storageLocation: z.enum(["server", "browser"]).default("server"),
 });


### PR DESCRIPTION
## ID
00005

## Type
Feature

## Description
Implement Browser Local Storage Option

Allow users to store their route history directly within their browsers
- Implements browser storage option for route histories and updates settings schema.

Allow users to store travel history directly within their browsers
- Implements browser storage option and migrates history/settings to individual objects.

Give users control over where their history data is stored for privacy
- Implements client-side browser storage option for user history via a "storageLocation" setting using Zod schema and updates server storage.

- Enable storing route history in the browser and adjust server storage Implements browser storage option, updating server routes and time check functions to handle storage location settings and API key retrieval.

Enable option to store route history locally within user's web browser
- Implements browser storage for route history and adds an API endpoint for fetching current route data.

## Testing
TESTED - OK

## Screenshot
<img width="1792" alt="image" src="https://github.com/user-attachments/assets/c4837691-94eb-4aff-9ddb-e98628f13166" />
